### PR TITLE
Update egui to 0.25 for egui_window_glfw_passthrough

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ egui = { workspace = true }
 
 
 [workspace.dependencies]
-egui = { version = "0.24.1", default-features = false }
+egui = { version = "0.25", default-features = false }
 bytemuck = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false }
 raw-window-handle = { version = "0.5" }

--- a/crates/egui_window_glfw_passthrough/src/lib.rs
+++ b/crates/egui_window_glfw_passthrough/src/lib.rs
@@ -486,6 +486,7 @@ impl GlfwBackend {
                             pressed: pressed.unwrap_or_default(),
                             modifiers: glfw_to_egui_modifers(m),
                             repeat,
+                            physical_key: None
                         }
                     })
                 }),


### PR DESCRIPTION
Hi, I was having trouble getting egui-glow to work with egui_window_glfw_passthrough so I decided to update to the latest egui version. I haven't tested the other crates in the workspace. `Event::Key` now has a `physical_key` field that should be set via the key scancode, but I'd rather not write a function that maps the scancode to the key right now.