### PR TITLE
Update egui to 0.32.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ egui_render_wgpu = { version = "0.9", path = "crates/egui_render_wgpu", optional
 
 
 [workspace.dependencies]
-egui = { version = "0.29", default-features = false }
+egui = { version = "0.32.1", default-features = false }
 bytemuck = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false }
 raw-window-handle = { version = "0.6" }

--- a/crates/egui_render_glow/src/lib.rs
+++ b/crates/egui_render_glow/src/lib.rs
@@ -317,13 +317,6 @@ impl Painter {
                     c.pixels.iter().flat_map(egui::Color32::to_array).collect(),
                     c.size,
                 ),
-                egui::ImageData::Font(font_image) => (
-                    font_image
-                        .srgba_pixels(None)
-                        .flat_map(|c| c.to_array())
-                        .collect(),
-                    font_image.size,
-                ),
             };
             if let Some(pos) = delta.pos {
                 glow_context.tex_sub_image_2d(

--- a/crates/egui_render_wgpu/src/painter.rs
+++ b/crates/egui_render_wgpu/src/painter.rs
@@ -423,7 +423,6 @@ impl EguiPainter {
             };
             let data_color32 = match delta.image {
                 ImageData::Color(color_image) => color_image.pixels.clone(),
-                ImageData::Font(font_image) => font_image.srgba_pixels(None).collect::<Vec<_>>(),
             };
 
             let data_bytes: &[u8] = bytemuck::cast_slice(data_color32.as_slice());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,10 +156,10 @@ impl<T: EguiOverlay + 'static> OverlayApp<T> {
                 user_data.run(egui_context, default_gfx_backend, glfw_backend)
             {
                 wait_events_duration = timeout.min(std::time::Duration::from_secs(1));
-                if !platform_output.copied_text.is_empty() {
-                    glfw_backend
-                        .window
-                        .set_clipboard_string(&platform_output.copied_text);
+                for command in &platform_output.commands {
+                    if let egui::output::OutputCommand::CopyText(text) = command {
+                        glfw_backend.window.set_clipboard_string(text);
+                    }
                 }
                 glfw_backend.set_cursor(platform_output.cursor_icon);
             } else {


### PR DESCRIPTION
- Update egui to latest version 0.32.1
- Remove `egui::ImageData::Font` enum variant removed in emilk/egui/pull/7298
- Fix clipboard handling deprecation warning

I'm just getting started with this, not sure if the removal of `ImageData::Font` needs to be handled in some other way, but I don't see any issues in the example by just removing it.

Fixes #48 